### PR TITLE
Dart版 SymbolRestClient: http/intl パッケージ のバージョンアップ

### DIFF
--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
   collection: '^1.17.0'
-  http: '^0.13.6'
+  http: '^1.2.2'
   intl: '^0.19.0'
   meta: '^1.1.8'
 dev_dependencies:

--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   collection: '^1.17.0'
   http: '^0.13.6'
-  intl: '^0.18.0'
+  intl: '^0.19.0'
   meta: '^1.1.8'
 dev_dependencies:
   test: '>=1.16.0 <1.18.0'


### PR DESCRIPTION
# 概要

プロジェクト内で使用している他のパッケージとsymbol-rest-clientのhttp と intl のバージョンに不整合があり、ビルドや実行時に警告やエラーが発生する可能性があったためバージョン不整合を解消し、依存パッケージを更新しました。

